### PR TITLE
Downgrade Underscore to be java 8 compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>kafka-connect-transform-record2jsonstring</groupId>
     <artifactId>kafka-connect-transform-record2jsonstring</artifactId>
-    <version>1.0</version>
+    <version>1.3</version>
     <description>Kafka Connect single message transform (SMT) taking a record (with schema) and transforms it into a single JSON String
     </description>
     <url>https://github.com/an0r0c/kafka-connect-transform-tojsonstring</url>
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>com.github.javadev</groupId>
             <artifactId>underscore</artifactId>
-            <version>1.82</version>
+            <version>1.81</version>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/src/test/java/com/github/cedelsb/kafka/connect/smt/Record2JsonStringConverterTest.java
+++ b/src/test/java/com/github/cedelsb/kafka/connect/smt/Record2JsonStringConverterTest.java
@@ -17,6 +17,7 @@
 package com.github.cedelsb.kafka.connect.smt;
 
 import org.apache.kafka.connect.data.*;
+import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,10 +27,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -246,6 +244,8 @@ public class Record2JsonStringConverterTest {
         props.put("json.writer.datetime.logical.types.as", "STRING");
         props.put("json.writer.datetime.pattern", "dd.MM.yyyy HH:mm z");
         props.put("json.writer.datetime.zoneid", "CET");
+
+        Locale.setDefault(new Locale("en", "GB")); // Force Locale to be English so that the timezone display name is properly returned
 
         valueSmt.configure(props);
 


### PR DESCRIPTION
- change version of Underscore to 1.81  for Java 8 compatibility
- adopt tests to enforce en as Locale to prevent failing on local Laptop with german locale 