### PR TITLE
Enable to pass empty ArrayList in schemaless

### DIFF
--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/JsonSchemalessRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/JsonSchemalessRecordConverter.java
@@ -24,6 +24,7 @@ import org.bson.codecs.BsonValueCodecProvider;
 import org.bson.codecs.DocumentCodecProvider;
 import org.bson.codecs.MapCodecProvider;
 import org.bson.codecs.ValueCodecProvider;
+import org.bson.codecs.IterableCodecProvider;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 
@@ -36,7 +37,8 @@ public class JsonSchemalessRecordConverter implements RecordConverter {
                         new DocumentCodecProvider(),
                         new BsonValueCodecProvider(),
                         new ValueCodecProvider(),
-                        new MapCodecProvider()
+                        new MapCodecProvider(),
+                        new IterableCodecProvider()
                 );
 
     @Override

--- a/src/test/java/com/github/cedelsb/kafka/connect/smt/Record2JsonStringConverterTest.java
+++ b/src/test/java/com/github/cedelsb/kafka/connect/smt/Record2JsonStringConverterTest.java
@@ -211,6 +211,28 @@ public class Record2JsonStringConverterTest {
     }
 
     @Test
+    public void transformRecordValue2JsonStringWithoutSchemaWithEmptyArrayListTest() {
+        // value for json format without schema
+        HashMap<String, Object> simpleValueWithoutSchema = new LinkedHashMap<>();
+        simpleValueWithoutSchema.put("emptyArrayList", new ArrayList<>());
+
+        final Map<String, Object> props = new HashMap<>();
+        props.put("json.string.field.name", "myawesomejsonstringfield");
+
+        valueSmt.configure(props);
+        final SinkRecord record = new SinkRecord(null, 0, null, null, null, simpleValueWithoutSchema, 0);
+        final SinkRecord transformedRecord = valueSmt.apply(record);
+
+        assertEquals(1, transformedRecord.valueSchema().fields().size());
+        assertEquals(Schema.STRING_SCHEMA,transformedRecord.valueSchema().field("myawesomejsonstringfield").schema());
+
+        Struct value = (Struct) transformedRecord.value();
+        String jsonString = (String) value.get("myawesomejsonstringfield");
+
+        assertEquals("{\"emptyArrayList\": []}", jsonString);
+    }
+
+    @Test
     public void transformRecordValue2JsonStringLogicalTypesDatetimeAsStringTest() {
         final Map<String, Object> props = new HashMap<>();
 


### PR DESCRIPTION
like #19 , smt failed when empty ArrayList is contained.
my env is not using schema registry and same problem occurred, i fixed to pass transform when empty arraylist included