### PR TITLE
Bugfix for null structs in maps, opt-in support for unwrapping Avro unions, and refactoring

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,12 +30,13 @@ It also was only tested with Avro Schemas backed by Confluent Schema Registry (b
   ////
   "transforms": "tojson",
   "transforms.tojson.type": "com.github.cedelsb.kafka.connect.smt.Record2JsonStringConverter$Value",
-  "transforms.tojson.json.string.field.name" : "myawesomejsonstring", // Optional 
-  "transforms.tojson.post.processing.to.xml" : false, // Optional 
-  "transforms.tojson.json.writer.handle.logical.types" : true, // Optional 
-  "transforms.tojson.json.writer.datetime.logical.types.as" : "STRING", // Optional 
-  "transforms.tojson.json.writer.datetime.pattern" : "", // Optional   
-  "transforms.tojson.json.writer.datetime.zoneid" : "UTC" // Optional   
+  "transforms.tojson.json.string.field.name" : "myawesomejsonstring", // Optional
+  "transforms.tojson.post.processing.to.xml" : false, // Optional
+  "transforms.tojson.json.writer.handle.logical.types" : true, // Optional
+  "transforms.tojson.json.writer.datetime.logical.types.as" : "STRING", // Optional
+  "transforms.tojson.json.writer.datetime.pattern" : "", // Optional
+  "transforms.tojson.json.writer.datetime.zoneid" : "UTC", // Optional
+  "transforms.tojson.avro.union.unwrap.enabled" : false // Optional
   ////
 }
 ```
@@ -76,6 +77,11 @@ It also was only tested with Avro Schemas backed by Confluent Schema Registry (b
 <td>json.writer.datetime.zoneid</td>
 <td>The ZoneId to use to format the date/time or timestamp as string, only applicable if json.writer.datetime.logical.types.as=STRING</td>
 <td>string</td><td>UTC</td><td>a valid ZoneId string, such as Europe/Zurich, CET or UTC</td><td>high</td>
+</tr>
+<tr>
+<td>avro.union.unwrap.enabled</td>
+<td>Enable unwrapping of Avro union types. When enabled, union values are unwrapped to their actual value instead of outputting all union branches. When Avro unions are converted to Kafka Connect Structs (Confluent format), the struct contains fields for all union branches with the selected branch holding its value and other branches as null. With this setting enabled, only the actual selected value is output, omitting null branches.</td>
+<td>boolean</td><td>false</td><td>true/false</td><td>medium</td>
 </tr>
 </tbody></table>
 

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/Record2JsonStringConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/Record2JsonStringConverter.java
@@ -56,6 +56,7 @@ public abstract class Record2JsonStringConverter<R extends ConnectRecord<R>> imp
         public static final String JSON_WRITER_DATETIME_LOGICAL_TYPES_AS = "json.writer.datetime.logical.types.as";
         public static final String JSON_WRITER_DATETIME_PATTERN = "json.writer.datetime.pattern";
         public static final String JSON_WRITER_DATETIME_ZONE_ID = "json.writer.datetime.zoneid";
+        public static final String AVRO_UNION_UNWRAP_ENABLED = "avro.union.unwrap.enabled";
     }
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
@@ -72,8 +73,9 @@ public abstract class Record2JsonStringConverter<R extends ConnectRecord<R>> imp
             .define(ConfigName.JSON_WRITER_DATETIME_PATTERN, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW,
                     "The pattern (either a predefined constant or pattern letters) to use to format the date/time or timestamp as string, only applicable if json.writer.datetime.logical.types.as=STRING")
             .define(ConfigName.JSON_WRITER_DATETIME_ZONE_ID, ConfigDef.Type.STRING, "UTC", ConfigDef.Importance.LOW,
-                    "The zone id to use to format the date/time or timestamp as string, only applicable if json.writer.datetime.logical.types.as=STRING"
-            );
+                    "The zone id to use to format the date/time or timestamp as string, only applicable if json.writer.datetime.logical.types.as=STRING")
+            .define(ConfigName.AVRO_UNION_UNWRAP_ENABLED, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.MEDIUM,
+                    "Enable unwrapping of Avro union types. When enabled, union values are unwrapped to their actual value instead of outputting all union branches. Only the selected branch value is output, other branches (which are null) are omitted.");
 
     private static final String PURPOSE = "Converting record with Schema into a simple JSON String";
 
@@ -85,6 +87,7 @@ public abstract class Record2JsonStringConverter<R extends ConnectRecord<R>> imp
     private String writeDatetimeWithZoneId;
 
     private boolean handleLogicalTypes;
+    private boolean avroUnionUnwrapEnabled;
 
     AvroJsonSchemafulRecordConverter converter;
     JsonSchemalessRecordConverter converterWithoutSchema;
@@ -99,6 +102,7 @@ public abstract class Record2JsonStringConverter<R extends ConnectRecord<R>> imp
         writeDatetimeLogicalTypesAs = config.getString(ConfigName.JSON_WRITER_DATETIME_LOGICAL_TYPES_AS);
         writeDatetimeWithPattern = config.getString(ConfigName.JSON_WRITER_DATETIME_PATTERN);
         writeDatetimeWithZoneId = config.getString(ConfigName.JSON_WRITER_DATETIME_ZONE_ID);
+        avroUnionUnwrapEnabled = config.getBoolean(ConfigName.AVRO_UNION_UNWRAP_ENABLED);
 
         if (handleLogicalTypes) {
             Converter<Long> dateTimeConverter = null;
@@ -124,7 +128,7 @@ public abstract class Record2JsonStringConverter<R extends ConnectRecord<R>> imp
                     .build();
         }
 
-        converter = new AvroJsonSchemafulRecordConverter();
+        converter = new AvroJsonSchemafulRecordConverter(avroUnionUnwrapEnabled);
         converterWithoutSchema = new JsonSchemalessRecordConverter();
 
         transformToXML = config.getBoolean(ConfigName.POST_PROCESSING_TO_XML);

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -122,7 +122,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
 
         if (isSupportedLogicalType(field.schema())) {
             logger.trace("handling logical type '{}' name='{}'", field.schema().name(), field.name());
-            value = handleLogicalTypeField(struct.get(field), field);
+            value = handleSimpleField(struct.get(field), field);
         } else {
             try {
                 switch (field.schema().type()) {
@@ -136,7 +136,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
                     case STRING:
                     case BYTES:
                         logger.trace("handling primitive type '{}' name='{}'", field.schema().type(), field.name());
-                        value = handlePrimitiveField(struct.get(field), field);
+                        value = handleSimpleField(struct.get(field), field);
                         break;
                     case STRUCT:
                         logger.trace("handling struct field='{}' schema.name='{}' schema.type='{}'",
@@ -166,7 +166,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         doc.put(field.name(), value);
     }
 
-    private BsonValue handleLogicalTypeField(Object value, Field field) {
+    private BsonValue handleSimpleField(Object value, Field field) {
         return getConverter(field.schema()).toBson(value, field.schema());
     }
 
@@ -319,10 +319,6 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         }
 
         return mapDoc;
-    }
-
-    private BsonValue handlePrimitiveField(Object value, Field field) {
-        return getConverter(field.schema()).toBson(value, field.schema());
     }
 
     private boolean isSupportedLogicalType(Schema schema) {

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -40,6 +40,7 @@ import java.util.*;
 public class AvroJsonSchemafulRecordConverter implements RecordConverter {
 
     private static final Logger logger = LoggerFactory.getLogger(AvroJsonSchemafulRecordConverter.class);
+    private static final String CONFLUENT_UNION_MARKER = "io.confluent.connect.avro.Union";
 
     public static final Set<String> LOGICAL_TYPE_NAMES = new HashSet<>(
             Arrays.asList(Date.LOGICAL_NAME, Decimal.LOGICAL_NAME,
@@ -48,8 +49,14 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
 
     private final Map<Schema.Type, SinkFieldConverter> converters = new HashMap<>();
     private final Map<String, SinkFieldConverter> logicalConverters = new HashMap<>();
+    private final boolean unionUnwrapEnabled;
 
     public AvroJsonSchemafulRecordConverter() {
+        this(false);
+    }
+
+    public AvroJsonSchemafulRecordConverter(boolean unionUnwrapEnabled) {
+        this.unionUnwrapEnabled = unionUnwrapEnabled;
 
         //standard types
         registerSinkFieldConverter(new BooleanFieldConverter());
@@ -89,6 +96,15 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         BsonDocument doc = new BsonDocument();
         schema.fields().forEach(f -> processField(doc, (Struct) value, f));
         return doc;
+    }
+
+    /**
+     * Detects if a schema represents an Avro union type using Confluent's marker.
+     */
+    private boolean isUnionStruct(Schema schema) {
+        return schema != null
+               && schema.type() == Schema.Type.STRUCT
+               && CONFLUENT_UNION_MARKER.equals(schema.name());
     }
 
     private void processField(BsonDocument doc, Struct struct, Field field) {
@@ -171,7 +187,29 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         }
 
         logger.trace(struct.toString());
-        doc.put(field.name(), toBsonDoc(field.schema(), struct));
+        if (unionUnwrapEnabled && isUnionStruct(field.schema())) {
+            unwrapAndPutUnion(doc, struct, field);
+        } else {
+            doc.put(field.name(), toBsonDoc(field.schema(), struct));
+        }
+    }
+
+    /**
+     * Unwraps an Avro union struct and outputs only the selected branch value.
+     * Union structs have multiple optional fields (one per branch), but only one should be non-null.
+     */
+    private void unwrapAndPutUnion(BsonDocument doc, Struct struct, Field field) {
+        for (Field unionBranch : field.schema().fields()) {
+            Object branchValue = struct.get(unionBranch);
+            if (branchValue != null) {
+                BsonValue unwrappedValue = convertValue(unionBranch.schema(), branchValue);
+                doc.put(field.name(), unwrappedValue);
+                return; // Only one branch should have a value
+            }
+        }
+
+        // If all branches were null, output BsonNull
+        doc.put(field.name(), BsonNull.VALUE);
     }
 
     /**
@@ -203,14 +241,21 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     /**
-     * Converts a struct value to a BsonDocument.
+     * Converts a struct value, detecting and unwrapping unions if enabled and necessary.
      */
     private BsonValue convertStructValue(Schema schema, Struct struct) {
-        return toBsonDoc(schema, struct);
+        if (unionUnwrapEnabled && isUnionStruct(schema)) {
+            BsonDocument tempDoc = new BsonDocument();
+            Field tempField = new Field("temp", 0, schema);
+            unwrapAndPutUnion(tempDoc, struct, tempField);
+            return tempDoc.get("temp");
+        } else {
+            return toBsonDoc(schema, struct);
+        }
     }
 
     /**
-     * Converts a map to a BsonDocument.
+     * Converts a map to a BsonDocument, handling union-typed values.
      */
     private BsonDocument convertMapValue(Schema mapSchema, Map<String, Object> mapValue) {
         BsonDocument mapDoc = new BsonDocument();

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -179,23 +179,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     private BsonValue handleStructField(Struct struct, Field field) {
-        if (struct == null) {
-            logger.trace("  field='{}' has null struct value", field.name());
-            return BsonNull.VALUE;
-        }
-
-        logger.trace("  struct value: {}", struct.toString());
-
-        boolean isUnion = unionUnwrapEnabled && isUnionStruct(field.schema());
-        logger.trace("  isUnionStruct={} unionUnwrapEnabled={} for schema.name='{}'",
-                     isUnion, unionUnwrapEnabled, field.schema().name());
-
-        if (isUnion) {
-            return unwrapUnion(field.schema(), struct);
-        } else {
-            logger.trace("  processing as regular struct with {} fields", field.schema().fields().size());
-            return toBsonDoc(field.schema(), struct);
-        }
+        return convertStructValue(field.schema(), struct);
     }
 
     /**
@@ -253,11 +237,21 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
      * Converts a struct value, detecting and unwrapping unions if enabled and necessary.
      */
     private BsonValue convertStructValue(Schema schema, Struct struct) {
+        if (struct == null) {
+            logger.trace("  struct is null");
+            return BsonNull.VALUE;
+        }
 
-        if (unionUnwrapEnabled && isUnionStruct(schema)) {
-            logger.trace("convertStructValue: detected union struct, unwrapping");
+        logger.trace("  struct value: {}", struct.toString());
+
+        boolean isUnion = isUnionStruct(schema);
+        logger.trace("  isUnionStruct={} unionUnwrapEnabled={} for schema.name='{}'",
+                     isUnion, unionUnwrapEnabled, schema.name());
+
+        if (unionUnwrapEnabled && isUnion) {
             return unwrapUnion(schema, struct);
         } else {
+            logger.trace("  processing as regular struct with {} fields", schema.fields().size());
             return toBsonDoc(schema, struct);
         }
     }

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -31,20 +31,23 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
-//looks like Avro and JSON + Schema is convertible by means of
-//a unified conversion approach since they are using the
-//same the Struct/Type information ...
+/**
+ * Converts Kafka Connect records with Avro or JSON schemas to BSON documents.
+ *
+ * Looks like Avro and JSON + Schema are convertible by means of a unified
+ * conversion approach since they are using the same the Struct/Type information.
+ */
 public class AvroJsonSchemafulRecordConverter implements RecordConverter {
+
+    private static final Logger logger = LoggerFactory.getLogger(AvroJsonSchemafulRecordConverter.class);
 
     public static final Set<String> LOGICAL_TYPE_NAMES = new HashSet<>(
             Arrays.asList(Date.LOGICAL_NAME, Decimal.LOGICAL_NAME,
-                            Time.LOGICAL_NAME, Timestamp.LOGICAL_NAME)
-        );
+                          Time.LOGICAL_NAME, Timestamp.LOGICAL_NAME)
+    );
 
     private final Map<Schema.Type, SinkFieldConverter> converters = new HashMap<>();
     private final Map<String, SinkFieldConverter> logicalConverters = new HashMap<>();
-
-    private static Logger logger = LoggerFactory.getLogger(AvroJsonSchemafulRecordConverter.class);
 
     public AvroJsonSchemafulRecordConverter() {
 
@@ -68,13 +71,10 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
 
     @Override
     public BsonDocument convert(Schema schema, Object value) {
-
-        if(schema == null || value == null) {
+        if (schema == null || value == null) {
             throw new DataException("error: schema and/or value was null for AVRO conversion");
         }
-
         return toBsonDoc(schema, value);
-
     }
 
     private void registerSinkFieldConverter(SinkFieldConverter converter) {
@@ -87,21 +87,20 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
 
     private BsonDocument toBsonDoc(Schema schema, Object value) {
         BsonDocument doc = new BsonDocument();
-        schema.fields().forEach(f -> processField(doc, (Struct)value, f));
+        schema.fields().forEach(f -> processField(doc, (Struct) value, f));
         return doc;
     }
 
     private void processField(BsonDocument doc, Struct struct, Field field) {
+        logger.trace("processing field '{}'", field.name());
 
-        logger.trace("processing field '{}'",field.name());
-
-        if(isSupportedLogicalType(field.schema())) {
-            doc.put(field.name(), getConverter(field.schema()).toBson(struct.get(field),field.schema()));
+        if (isSupportedLogicalType(field.schema())) {
+            doc.put(field.name(), getConverter(field.schema()).toBson(struct.get(field), field.schema()));
             return;
         }
 
         try {
-            switch(field.schema().type()) {
+            switch (field.schema().type()) {
                 case BOOLEAN:
                 case FLOAT32:
                 case FLOAT64:
@@ -114,52 +113,47 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
                     handlePrimitiveField(doc, struct.get(field), field);
                     break;
                 case STRUCT:
-                    handleStructField(doc, (Struct)struct.get(field), field);
+                    handleStructField(doc, (Struct) struct.get(field), field);
                     break;
                 case ARRAY:
-                    doc.put(field.name(),handleArrayField((List)struct.get(field), field));
+                    doc.put(field.name(), handleArrayField((List) struct.get(field), field));
                     break;
                 case MAP:
-                    handleMapField(doc, (Map)struct.get(field), field);
+                    handleMapField(doc, (Map) struct.get(field), field);
                     break;
                 default:
-                    logger.error("Invalid schema. unexpected / unsupported schema type '"
-                                 + field.schema().type() + "' for field '"
-                                 + field.name() + "' value='" + struct + "'");
                     throw new DataException("unexpected / unsupported schema type " + field.schema().type());
             }
         } catch (Exception exc) {
-            logger.error("Error while processing field. schema type '"
-               + field.schema().type() + "' for field '"
-               + field.name() + "' value='" + struct + "'");
+            logger.error("Error processing field '{}' of type '{}': {}",
+                         field.name(), field.schema().type(), exc.getMessage());
             throw new DataException("error while processing field " + field.name(), exc);
         }
-
     }
 
     private void handleMapField(BsonDocument doc, Map m, Field field) {
         logger.trace("handling complex type 'map'");
-        if(m==null) {
+        if (m == null) {
             logger.trace("no field in struct -> adding null");
             doc.put(field.name(), BsonNull.VALUE);
             return;
         }
         BsonDocument bd = new BsonDocument();
-        for(Object entry : m.keySet()) {
-            String key = (String)entry;
+        for (Object entry : m.keySet()) {
+            String key = (String) entry;
             Object value = m.get(key);
             Schema.Type valueSchemaType = field.schema().valueSchema().type();
-            if(valueSchemaType.isPrimitive()) {
+            if (valueSchemaType.isPrimitive()) {
                 bd.put(key, getConverter(field.schema().valueSchema()).toBson(value, field.schema()));
             } else if (valueSchemaType.equals(Schema.Type.ARRAY)) {
                 final Field elementField = new Field(key, 0, field.schema().valueSchema());
-                final List list = (List)value;
+                final List list = (List) value;
                 logger.trace("adding array values to {} of type valueSchema={} value='{}'",
-                   elementField.name(), elementField.schema().valueSchema(), list);
+                             elementField.name(), elementField.schema().valueSchema(), list);
                 bd.put(key, handleArrayField(list, elementField));
             } else {
                 // Handle struct values in maps (including null values)
-                if(value == null) {
+                if (value == null) {
                     bd.put(key, BsonNull.VALUE);
                 } else {
                     bd.put(key, toBsonDoc(field.schema().valueSchema(), value));
@@ -171,19 +165,19 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
 
     private BsonValue handleArrayField(List list, Field field) {
         logger.trace("handling complex type 'array' of types '{}'",
-           field.schema().valueSchema().type());
-        if(list==null) {
+                     field.schema().valueSchema().type());
+        if (list == null) {
             logger.trace("no array -> adding null");
             return BsonNull.VALUE;
         }
         BsonArray array = new BsonArray();
         Schema.Type st = field.schema().valueSchema().type();
-        for(Object element : list) {
-            if(st.isPrimitive()) {
-                array.add(getConverter(field.schema().valueSchema()).toBson(element,field.schema()));
-            } else if(st == Schema.Type.ARRAY) {
+        for (Object element : list) {
+            if (st.isPrimitive()) {
+                array.add(getConverter(field.schema().valueSchema()).toBson(element, field.schema()));
+            } else if (st == Schema.Type.ARRAY) {
                 Field elementField = new Field("first", 0, field.schema().valueSchema());
-                array.add(handleArrayField((List)element,elementField));
+                array.add(handleArrayField((List) element, elementField));
             } else {
                 array.add(toBsonDoc(field.schema().valueSchema(), element));
             }
@@ -193,7 +187,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
 
     private void handleStructField(BsonDocument doc, Struct struct, Field field) {
         logger.trace("handling complex type 'struct'");
-        if(struct!=null) {
+        if (struct != null) {
             logger.trace(struct.toString());
             doc.put(field.name(), toBsonDoc(field.schema(), struct));
         } else {
@@ -203,25 +197,18 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     private void handlePrimitiveField(BsonDocument doc, Object value, Field field) {
-        logger.trace("handling primitive type '{}' name='{}'",field.schema().type(),field.name());
-        doc.put(field.name(), getConverter(field.schema()).toBson(value,field.schema()));
+        logger.trace("handling primitive type '{}' name='{}'", field.schema().type(), field.name());
+        doc.put(field.name(), getConverter(field.schema()).toBson(value, field.schema()));
     }
 
     private boolean isSupportedLogicalType(Schema schema) {
-
-        if(schema.name() == null) {
-            return false;
-        }
-
-        return LOGICAL_TYPE_NAMES.contains(schema.name());
-
+        return schema.name() != null && LOGICAL_TYPE_NAMES.contains(schema.name());
     }
 
     private SinkFieldConverter getConverter(Schema schema) {
-
         SinkFieldConverter converter;
 
-        if(isSupportedLogicalType(schema)) {
+        if (isSupportedLogicalType(schema)) {
             converter = logicalConverters.get(schema.name());
         } else {
             converter = converters.get(schema.type());

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -175,20 +175,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     private BsonValue handleArrayField(List list, Field field) {
-        if (list == null) {
-            logger.trace("  array is null");
-            return BsonNull.VALUE;
-        }
-
-        BsonArray array = new BsonArray();
-        Schema valueSchema = field.schema().valueSchema();
-
-        for (Object element : list) {
-            BsonValue convertedElement = convertValue(valueSchema, element);
-            array.add(convertedElement);
-        }
-
-        return array;
+        return convertArrayValue(field.schema(), list);
     }
 
     private BsonValue handleStructField(Struct struct, Field field) {
@@ -291,6 +278,23 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         } else {
             return toBsonDoc(schema, struct);
         }
+    }
+
+    private BsonValue convertArrayValue(Schema arraySchema, List arrayValue) {
+        if (arrayValue == null) {
+            logger.trace("  array is null");
+            return BsonNull.VALUE;
+        }
+
+        BsonArray array = new BsonArray();
+        Schema valueSchema = arraySchema.valueSchema();
+
+        for (Object element : arrayValue) {
+            BsonValue convertedElement = convertValue(valueSchema, element);
+            array.add(convertedElement);
+        }
+
+        return array;
     }
 
     /**

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -191,9 +191,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
                      isUnion, unionUnwrapEnabled, field.schema().name());
 
         if (isUnion) {
-            BsonDocument tempDoc = new BsonDocument();
-            unwrapAndPutUnion(tempDoc, struct, field);
-            return tempDoc.get(field.name());
+            return unwrapUnion(field.schema(), struct);
         } else {
             logger.trace("  processing as regular struct with {} fields", field.schema().fields().size());
             return toBsonDoc(field.schema(), struct);
@@ -201,39 +199,26 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     /**
-     * Unwraps an Avro union struct and outputs only the selected branch value.
+     * Unwraps an Avro union struct and returns the selected branch value.
      * Union structs have multiple optional fields (one per branch), but only one should be non-null.
      */
-    private void unwrapAndPutUnion(BsonDocument doc, Struct struct, Field field) {
-        logger.trace("unwrapping union field='{}' schema.name='{}'",
-                     field.name(), field.schema().name());
+    private BsonValue unwrapUnion(Schema schema, Struct struct) {
+        logger.trace("unwrapping union schema.name='{}'", schema.name());
 
-        int nonNullBranches = 0;
-
-        for (Field unionBranch : field.schema().fields()) {
+        for (Field unionBranch : schema.fields()) {
             Object branchValue = struct.get(unionBranch);
             logger.trace("  union branch='{}' type='{}' value.isNull={}",
                          unionBranch.name(), unionBranch.schema().type(), branchValue == null);
 
             if (branchValue != null) {
-                nonNullBranches++;
                 logger.trace("  selected branch='{}' type='{}' - unwrapping to parent field",
                              unionBranch.name(), unionBranch.schema().type());
-
-                BsonValue unwrappedValue = convertValue(unionBranch.schema(), branchValue);
-                doc.put(field.name(), unwrappedValue);
-                break; // Only one branch should have a value
+                return convertValue(unionBranch.schema(), branchValue);
             }
         }
 
-        logger.trace("  union unwrapping complete for field='{}', nonNullBranches={}",
-                     field.name(), nonNullBranches);
-
-        // If all branches were null, output BsonNull
-        if (!doc.containsKey(field.name())) {
-            logger.trace("  all union branches null for field='{}' - adding BsonNull", field.name());
-            doc.put(field.name(), BsonNull.VALUE);
-        }
+        logger.trace("  all union branches null - returning BsonNull");
+        return BsonNull.VALUE;
     }
 
     /**
@@ -271,10 +256,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
 
         if (unionUnwrapEnabled && isUnionStruct(schema)) {
             logger.trace("convertStructValue: detected union struct, unwrapping");
-            BsonDocument tempDoc = new BsonDocument();
-            Field tempField = new Field("temp", 0, schema);
-            unwrapAndPutUnion(tempDoc, struct, tempField);
-            return tempDoc.get("temp");
+            return unwrapUnion(schema, struct);
         } else {
             return toBsonDoc(schema, struct);
         }

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -138,29 +138,9 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
             doc.put(field.name(), BsonNull.VALUE);
             return;
         }
-        BsonDocument bd = new BsonDocument();
-        for (Object entry : m.keySet()) {
-            String key = (String) entry;
-            Object value = m.get(key);
-            Schema.Type valueSchemaType = field.schema().valueSchema().type();
-            if (valueSchemaType.isPrimitive()) {
-                bd.put(key, getConverter(field.schema().valueSchema()).toBson(value, field.schema()));
-            } else if (valueSchemaType.equals(Schema.Type.ARRAY)) {
-                final Field elementField = new Field(key, 0, field.schema().valueSchema());
-                final List list = (List) value;
-                logger.trace("adding array values to {} of type valueSchema={} value='{}'",
-                             elementField.name(), elementField.schema().valueSchema(), list);
-                bd.put(key, handleArrayField(list, elementField));
-            } else {
-                // Handle struct values in maps (including null values)
-                if (value == null) {
-                    bd.put(key, BsonNull.VALUE);
-                } else {
-                    bd.put(key, toBsonDoc(field.schema().valueSchema(), value));
-                }
-            }
-        }
-        doc.put(field.name(), bd);
+
+        BsonDocument mapDoc = convertMapValue(field.schema(), (Map<String, Object>) m);
+        doc.put(field.name(), mapDoc);
     }
 
     private BsonValue handleArrayField(List list, Field field) {
@@ -170,30 +150,78 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
             logger.trace("no array -> adding null");
             return BsonNull.VALUE;
         }
+
         BsonArray array = new BsonArray();
-        Schema.Type st = field.schema().valueSchema().type();
+        Schema valueSchema = field.schema().valueSchema();
+
         for (Object element : list) {
-            if (st.isPrimitive()) {
-                array.add(getConverter(field.schema().valueSchema()).toBson(element, field.schema()));
-            } else if (st == Schema.Type.ARRAY) {
-                Field elementField = new Field("first", 0, field.schema().valueSchema());
-                array.add(handleArrayField((List) element, elementField));
-            } else {
-                array.add(toBsonDoc(field.schema().valueSchema(), element));
-            }
+            BsonValue convertedElement = convertValue(valueSchema, element);
+            array.add(convertedElement);
         }
+
         return array;
     }
 
     private void handleStructField(BsonDocument doc, Struct struct, Field field) {
         logger.trace("handling complex type 'struct'");
-        if (struct != null) {
-            logger.trace(struct.toString());
-            doc.put(field.name(), toBsonDoc(field.schema(), struct));
-        } else {
+        if (struct == null) {
             logger.trace("no field in struct -> adding null");
             doc.put(field.name(), BsonNull.VALUE);
+            return;
         }
+
+        logger.trace(struct.toString());
+        doc.put(field.name(), toBsonDoc(field.schema(), struct));
+    }
+
+    /**
+     * Converts a value based on its schema type. Handles primitives, structs, arrays, and maps.
+     * This is a central conversion point that eliminates duplication.
+     */
+    private BsonValue convertValue(Schema schema, Object value) {
+        if (value == null) {
+            return BsonNull.VALUE;
+        }
+
+        Schema.Type type = schema.type();
+
+        if (type.isPrimitive() || isSupportedLogicalType(schema)) {
+            return getConverter(schema).toBson(value, schema);
+        }
+
+        switch (type) {
+            case STRUCT:
+                return convertStructValue(schema, (Struct) value);
+            case ARRAY:
+                Field arrayField = new Field("temp", 0, schema);
+                return handleArrayField((List) value, arrayField);
+            case MAP:
+                return convertMapValue(schema, (Map<String, Object>) value);
+            default:
+                throw new DataException("Unsupported schema type: " + type);
+        }
+    }
+
+    /**
+     * Converts a struct value to a BsonDocument.
+     */
+    private BsonValue convertStructValue(Schema schema, Struct struct) {
+        return toBsonDoc(schema, struct);
+    }
+
+    /**
+     * Converts a map to a BsonDocument.
+     */
+    private BsonDocument convertMapValue(Schema mapSchema, Map<String, Object> mapValue) {
+        BsonDocument mapDoc = new BsonDocument();
+        Schema valueSchema = mapSchema.valueSchema();
+
+        for (Map.Entry<String, Object> entry : mapValue.entrySet()) {
+            BsonValue convertedValue = convertValue(valueSchema, entry.getValue());
+            mapDoc.put(entry.getKey(), convertedValue);
+        }
+
+        return mapDoc;
     }
 
     private void handlePrimitiveField(BsonDocument doc, Object value, Field field) {

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -171,11 +171,6 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     private BsonValue handleMapField(Map m, Field field) {
-        if (m == null) {
-            logger.trace("  field='{}' has null map", field.name());
-            return BsonNull.VALUE;
-        }
-
         return convertMapValue(field.schema(), (Map<String, Object>) m);
     }
 
@@ -299,9 +294,14 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     /**
-     * Converts a map to a BsonDocument, handling union-typed values.
+     * Converts a map to a BsonValue, handling union-typed values and null maps.
      */
-    private BsonDocument convertMapValue(Schema mapSchema, Map<String, Object> mapValue) {
+    private BsonValue convertMapValue(Schema mapSchema, Map<String, Object> mapValue) {
+        if (mapValue == null) {
+            logger.trace("  map is null");
+            return BsonNull.VALUE;
+        }
+
         logger.trace("convertMapValue: processing map with {} entries", mapValue.size());
 
         BsonDocument mapDoc = new BsonDocument();

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -118,44 +118,14 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     private void processField(BsonDocument doc, Struct struct, Field field) {
         logger.trace("processing field '{}'", field.name());
 
-        BsonValue value;
-
-        if (isSupportedLogicalType(field.schema())) {
-            value = convertSimpleValue(field.schema(), struct.get(field));
-        } else {
-            try {
-                switch (field.schema().type()) {
-                    case BOOLEAN:
-                    case FLOAT32:
-                    case FLOAT64:
-                    case INT8:
-                    case INT16:
-                    case INT32:
-                    case INT64:
-                    case STRING:
-                    case BYTES:
-                        value = convertSimpleValue(field.schema(), struct.get(field));
-                        break;
-                    case STRUCT:
-                        value = convertStructValue(field.schema(), (Struct) struct.get(field));
-                        break;
-                    case ARRAY:
-                        value = convertArrayValue(field.schema(), (List) struct.get(field));
-                        break;
-                    case MAP:
-                        value = convertMapValue(field.schema(), (Map) struct.get(field));
-                        break;
-                    default:
-                        throw new DataException("unexpected / unsupported schema type " + field.schema().type());
-                }
-            } catch (Exception exc) {
-                logger.error("Error processing field '{}' of type '{}': {}",
-                             field.name(), field.schema().type(), exc.getMessage());
-                throw new DataException("error while processing field " + field.name(), exc);
-            }
+        try {
+            BsonValue value = convertValue(field.schema(), struct.get(field));
+            doc.put(field.name(), value);
+        } catch (Exception exc) {
+            logger.error("Error processing field '{}' of type '{}': {}",
+                         field.name(), field.schema().type(), exc.getMessage());
+            throw new DataException("error while processing field " + field.name(), exc);
         }
-
-        doc.put(field.name(), value);
     }
 
     private BsonValue convertSimpleValue(Schema schema, Object value) {

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -147,17 +147,23 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         BsonDocument bd = new BsonDocument();
         for(Object entry : m.keySet()) {
             String key = (String)entry;
+            Object value = m.get(key);
             Schema.Type valueSchemaType = field.schema().valueSchema().type();
             if(valueSchemaType.isPrimitive()) {
-                bd.put(key, getConverter(field.schema().valueSchema()).toBson(m.get(key),field.schema()));
+                bd.put(key, getConverter(field.schema().valueSchema()).toBson(value, field.schema()));
             } else if (valueSchemaType.equals(Schema.Type.ARRAY)) {
                 final Field elementField = new Field(key, 0, field.schema().valueSchema());
-                final List list = (List)m.get(key);
+                final List list = (List)value;
                 logger.trace("adding array values to {} of type valueSchema={} value='{}'",
                    elementField.name(), elementField.schema().valueSchema(), list);
                 bd.put(key, handleArrayField(list, elementField));
             } else {
-                bd.put(key, toBsonDoc(field.schema().valueSchema(), m.get(key)));
+                // Handle struct values in maps (including null values)
+                if(value == null) {
+                    bd.put(key, BsonNull.VALUE);
+                } else {
+                    bd.put(key, toBsonDoc(field.schema().valueSchema(), value));
+                }
             }
         }
         doc.put(field.name(), bd);

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -129,10 +129,6 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     private BsonValue convertSimpleValue(Schema schema, Object value) {
-        if (value == null) {
-            return BsonNull.VALUE;
-        }
-
         if (isSupportedLogicalType(schema)) {
             logger.trace("converting logical type '{}'", schema.name());
         } else {
@@ -196,11 +192,6 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
      * Converts a struct value, detecting and unwrapping unions if enabled and necessary.
      */
     private BsonValue convertStructValue(Schema schema, Struct struct) {
-        if (struct == null) {
-            logger.trace("  struct is null");
-            return BsonNull.VALUE;
-        }
-
         logger.trace("converting struct schema.name='{}' schema.type='{}' value: {}",
                      schema.name(), schema.type(), struct.toString());
 
@@ -217,11 +208,6 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     private BsonValue convertArrayValue(Schema arraySchema, List arrayValue) {
-        if (arrayValue == null) {
-            logger.trace("  array is null");
-            return BsonNull.VALUE;
-        }
-
         logger.trace("converting array valueSchema.type='{}'", arraySchema.valueSchema().type());
 
         BsonArray array = new BsonArray();
@@ -239,11 +225,6 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
      * Converts a map to a BsonValue, handling union-typed values and null maps.
      */
     private BsonValue convertMapValue(Schema mapSchema, Map<String, Object> mapValue) {
-        if (mapValue == null) {
-            logger.trace("  map is null");
-            return BsonNull.VALUE;
-        }
-
         logger.trace("converting map valueSchema.type='{}' entries={}",
                      mapSchema.valueSchema().type(), mapValue.size());
 

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -121,6 +121,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         BsonValue value;
 
         if (isSupportedLogicalType(field.schema())) {
+            logger.trace("handling logical type '{}' name='{}'", field.schema().name(), field.name());
             value = handleLogicalTypeField(struct.get(field), field);
         } else {
             try {
@@ -134,15 +135,22 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
                     case INT64:
                     case STRING:
                     case BYTES:
+                        logger.trace("handling primitive type '{}' name='{}'", field.schema().type(), field.name());
                         value = handlePrimitiveField(struct.get(field), field);
                         break;
                     case STRUCT:
+                        logger.trace("handling struct field='{}' schema.name='{}' schema.type='{}'",
+                                     field.name(), field.schema().name(), field.schema().type());
                         value = handleStructField((Struct) struct.get(field), field);
                         break;
                     case ARRAY:
+                        logger.trace("handling array field='{}' valueSchema.type='{}'",
+                                     field.name(), field.schema().valueSchema().type());
                         value = handleArrayField((List) struct.get(field), field);
                         break;
                     case MAP:
+                        logger.trace("handling map field='{}' valueSchema.type='{}'",
+                                     field.name(), field.schema().valueSchema().type());
                         value = handleMapField((Map) struct.get(field), field);
                         break;
                     default:
@@ -159,14 +167,10 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     private BsonValue handleLogicalTypeField(Object value, Field field) {
-        logger.trace("handling logical type '{}' name='{}'", field.schema().name(), field.name());
         return getConverter(field.schema()).toBson(value, field.schema());
     }
 
     private BsonValue handleMapField(Map m, Field field) {
-        logger.trace("handling map field='{}' valueSchema.type='{}'",
-                     field.name(), field.schema().valueSchema().type());
-
         if (m == null) {
             logger.trace("  field='{}' has null map", field.name());
             return BsonNull.VALUE;
@@ -176,9 +180,6 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     private BsonValue handleArrayField(List list, Field field) {
-        logger.trace("handling array field='{}' valueSchema.type='{}'",
-                     field.name(), field.schema().valueSchema().type());
-
         if (list == null) {
             logger.trace("  array is null");
             return BsonNull.VALUE;
@@ -196,9 +197,6 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     private BsonValue handleStructField(Struct struct, Field field) {
-        logger.trace("handling struct field='{}' schema.name='{}' schema.type='{}'",
-                     field.name(), field.schema().name(), field.schema().type());
-
         if (struct == null) {
             logger.trace("  field='{}' has null struct value", field.name());
             return BsonNull.VALUE;
@@ -324,7 +322,6 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     private BsonValue handlePrimitiveField(Object value, Field field) {
-        logger.trace("handling primitive type '{}' name='{}'", field.schema().type(), field.name());
         return getConverter(field.schema()).toBson(value, field.schema());
     }
 

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -121,7 +121,6 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         BsonValue value;
 
         if (isSupportedLogicalType(field.schema())) {
-            logger.trace("handling logical type '{}' name='{}'", field.schema().name(), field.name());
             value = convertSimpleValue(field.schema(), struct.get(field));
         } else {
             try {
@@ -135,22 +134,15 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
                     case INT64:
                     case STRING:
                     case BYTES:
-                        logger.trace("handling primitive type '{}' name='{}'", field.schema().type(), field.name());
                         value = convertSimpleValue(field.schema(), struct.get(field));
                         break;
                     case STRUCT:
-                        logger.trace("handling struct field='{}' schema.name='{}' schema.type='{}'",
-                                     field.name(), field.schema().name(), field.schema().type());
                         value = convertStructValue(field.schema(), (Struct) struct.get(field));
                         break;
                     case ARRAY:
-                        logger.trace("handling array field='{}' valueSchema.type='{}'",
-                                     field.name(), field.schema().valueSchema().type());
                         value = convertArrayValue(field.schema(), (List) struct.get(field));
                         break;
                     case MAP:
-                        logger.trace("handling map field='{}' valueSchema.type='{}'",
-                                     field.name(), field.schema().valueSchema().type());
                         value = convertMapValue(field.schema(), (Map) struct.get(field));
                         break;
                     default:
@@ -170,6 +162,13 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         if (value == null) {
             return BsonNull.VALUE;
         }
+
+        if (isSupportedLogicalType(schema)) {
+            logger.trace("converting logical type '{}'", schema.name());
+        } else {
+            logger.trace("converting primitive type '{}'", schema.type());
+        }
+
         return getConverter(schema).toBson(value, schema);
     }
 
@@ -232,7 +231,8 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
             return BsonNull.VALUE;
         }
 
-        logger.trace("  struct value: {}", struct.toString());
+        logger.trace("converting struct schema.name='{}' schema.type='{}' value: {}",
+                     schema.name(), schema.type(), struct.toString());
 
         boolean isUnion = isUnionStruct(schema);
         logger.trace("  isUnionStruct={} unionUnwrapEnabled={} for schema.name='{}'",
@@ -251,6 +251,8 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
             logger.trace("  array is null");
             return BsonNull.VALUE;
         }
+
+        logger.trace("converting array valueSchema.type='{}'", arraySchema.valueSchema().type());
 
         BsonArray array = new BsonArray();
         Schema valueSchema = arraySchema.valueSchema();
@@ -272,7 +274,8 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
             return BsonNull.VALUE;
         }
 
-        logger.trace("convertMapValue: processing map with {} entries", mapValue.size());
+        logger.trace("converting map valueSchema.type='{}' entries={}",
+                     mapSchema.valueSchema().type(), mapValue.size());
 
         BsonDocument mapDoc = new BsonDocument();
         Schema valueSchema = mapSchema.valueSchema();

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -81,6 +81,10 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         if (schema == null || value == null) {
             throw new DataException("error: schema and/or value was null for AVRO conversion");
         }
+
+        logger.trace("convert() entry: schema.name='{}' schema.type='{}' value.class='{}'",
+                     schema.name(), schema.type(), value.getClass().getSimpleName());
+
         return toBsonDoc(schema, value);
     }
 
@@ -148,9 +152,11 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     private void handleMapField(BsonDocument doc, Map m, Field field) {
-        logger.trace("handling complex type 'map'");
+        logger.trace("handling map field='{}' valueSchema.type='{}'",
+                     field.name(), field.schema().valueSchema().type());
+
         if (m == null) {
-            logger.trace("no field in struct -> adding null");
+            logger.trace("  field='{}' has null map", field.name());
             doc.put(field.name(), BsonNull.VALUE);
             return;
         }
@@ -160,10 +166,11 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     private BsonValue handleArrayField(List list, Field field) {
-        logger.trace("handling complex type 'array' of types '{}'",
-                     field.schema().valueSchema().type());
+        logger.trace("handling array field='{}' valueSchema.type='{}'",
+                     field.name(), field.schema().valueSchema().type());
+
         if (list == null) {
-            logger.trace("no array -> adding null");
+            logger.trace("  array is null");
             return BsonNull.VALUE;
         }
 
@@ -179,17 +186,25 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     }
 
     private void handleStructField(BsonDocument doc, Struct struct, Field field) {
-        logger.trace("handling complex type 'struct'");
+        logger.trace("handling struct field='{}' schema.name='{}' schema.type='{}'",
+                     field.name(), field.schema().name(), field.schema().type());
+
         if (struct == null) {
-            logger.trace("no field in struct -> adding null");
+            logger.trace("  field='{}' has null struct value", field.name());
             doc.put(field.name(), BsonNull.VALUE);
             return;
         }
 
-        logger.trace(struct.toString());
-        if (unionUnwrapEnabled && isUnionStruct(field.schema())) {
+        logger.trace("  struct value: {}", struct.toString());
+
+        boolean isUnion = unionUnwrapEnabled && isUnionStruct(field.schema());
+        logger.trace("  isUnionStruct={} unionUnwrapEnabled={} for schema.name='{}'",
+                     isUnion, unionUnwrapEnabled, field.schema().name());
+
+        if (isUnion) {
             unwrapAndPutUnion(doc, struct, field);
         } else {
+            logger.trace("  processing as regular struct with {} fields", field.schema().fields().size());
             doc.put(field.name(), toBsonDoc(field.schema(), struct));
         }
     }
@@ -199,17 +214,35 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
      * Union structs have multiple optional fields (one per branch), but only one should be non-null.
      */
     private void unwrapAndPutUnion(BsonDocument doc, Struct struct, Field field) {
+        logger.trace("unwrapping union field='{}' schema.name='{}'",
+                     field.name(), field.schema().name());
+
+        int nonNullBranches = 0;
+
         for (Field unionBranch : field.schema().fields()) {
             Object branchValue = struct.get(unionBranch);
+            logger.trace("  union branch='{}' type='{}' value.isNull={}",
+                         unionBranch.name(), unionBranch.schema().type(), branchValue == null);
+
             if (branchValue != null) {
+                nonNullBranches++;
+                logger.trace("  selected branch='{}' type='{}' - unwrapping to parent field",
+                             unionBranch.name(), unionBranch.schema().type());
+
                 BsonValue unwrappedValue = convertValue(unionBranch.schema(), branchValue);
                 doc.put(field.name(), unwrappedValue);
-                return; // Only one branch should have a value
+                break; // Only one branch should have a value
             }
         }
 
+        logger.trace("  union unwrapping complete for field='{}', nonNullBranches={}",
+                     field.name(), nonNullBranches);
+
         // If all branches were null, output BsonNull
-        doc.put(field.name(), BsonNull.VALUE);
+        if (!doc.containsKey(field.name())) {
+            logger.trace("  all union branches null for field='{}' - adding BsonNull", field.name());
+            doc.put(field.name(), BsonNull.VALUE);
+        }
     }
 
     /**
@@ -244,7 +277,9 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
      * Converts a struct value, detecting and unwrapping unions if enabled and necessary.
      */
     private BsonValue convertStructValue(Schema schema, Struct struct) {
+
         if (unionUnwrapEnabled && isUnionStruct(schema)) {
+            logger.trace("convertStructValue: detected union struct, unwrapping");
             BsonDocument tempDoc = new BsonDocument();
             Field tempField = new Field("temp", 0, schema);
             unwrapAndPutUnion(tempDoc, struct, tempField);
@@ -258,12 +293,20 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
      * Converts a map to a BsonDocument, handling union-typed values.
      */
     private BsonDocument convertMapValue(Schema mapSchema, Map<String, Object> mapValue) {
+        logger.trace("convertMapValue: processing map with {} entries", mapValue.size());
+
         BsonDocument mapDoc = new BsonDocument();
         Schema valueSchema = mapSchema.valueSchema();
 
         for (Map.Entry<String, Object> entry : mapValue.entrySet()) {
-            BsonValue convertedValue = convertValue(valueSchema, entry.getValue());
-            mapDoc.put(entry.getKey(), convertedValue);
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            logger.trace("  map entry key='{}' valueSchemaType='{}' value.isNull={}",
+                         key, valueSchema.type(), value == null);
+
+            BsonValue convertedValue = convertValue(valueSchema, value);
+            mapDoc.put(key, convertedValue);
         }
 
         return mapDoc;

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -122,7 +122,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
 
         if (isSupportedLogicalType(field.schema())) {
             logger.trace("handling logical type '{}' name='{}'", field.schema().name(), field.name());
-            value = handleSimpleField(struct.get(field), field);
+            value = convertSimpleValue(field.schema(), struct.get(field));
         } else {
             try {
                 switch (field.schema().type()) {
@@ -136,22 +136,22 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
                     case STRING:
                     case BYTES:
                         logger.trace("handling primitive type '{}' name='{}'", field.schema().type(), field.name());
-                        value = handleSimpleField(struct.get(field), field);
+                        value = convertSimpleValue(field.schema(), struct.get(field));
                         break;
                     case STRUCT:
                         logger.trace("handling struct field='{}' schema.name='{}' schema.type='{}'",
                                      field.name(), field.schema().name(), field.schema().type());
-                        value = handleStructField((Struct) struct.get(field), field);
+                        value = convertStructValue(field.schema(), (Struct) struct.get(field));
                         break;
                     case ARRAY:
                         logger.trace("handling array field='{}' valueSchema.type='{}'",
                                      field.name(), field.schema().valueSchema().type());
-                        value = handleArrayField((List) struct.get(field), field);
+                        value = convertArrayValue(field.schema(), (List) struct.get(field));
                         break;
                     case MAP:
                         logger.trace("handling map field='{}' valueSchema.type='{}'",
                                      field.name(), field.schema().valueSchema().type());
-                        value = handleMapField((Map) struct.get(field), field);
+                        value = convertMapValue(field.schema(), (Map) struct.get(field));
                         break;
                     default:
                         throw new DataException("unexpected / unsupported schema type " + field.schema().type());
@@ -166,20 +166,11 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         doc.put(field.name(), value);
     }
 
-    private BsonValue handleSimpleField(Object value, Field field) {
-        return getConverter(field.schema()).toBson(value, field.schema());
-    }
-
-    private BsonValue handleMapField(Map m, Field field) {
-        return convertMapValue(field.schema(), (Map<String, Object>) m);
-    }
-
-    private BsonValue handleArrayField(List list, Field field) {
-        return convertArrayValue(field.schema(), list);
-    }
-
-    private BsonValue handleStructField(Struct struct, Field field) {
-        return convertStructValue(field.schema(), struct);
+    private BsonValue convertSimpleValue(Schema schema, Object value) {
+        if (value == null) {
+            return BsonNull.VALUE;
+        }
+        return getConverter(schema).toBson(value, schema);
     }
 
     /**

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -118,60 +118,61 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
     private void processField(BsonDocument doc, Struct struct, Field field) {
         logger.trace("processing field '{}'", field.name());
 
+        BsonValue value;
+
         if (isSupportedLogicalType(field.schema())) {
-            handleLogicalTypeField(doc, struct.get(field), field);
-            return;
-        }
-
-        try {
-            switch (field.schema().type()) {
-                case BOOLEAN:
-                case FLOAT32:
-                case FLOAT64:
-                case INT8:
-                case INT16:
-                case INT32:
-                case INT64:
-                case STRING:
-                case BYTES:
-                    handlePrimitiveField(doc, struct.get(field), field);
-                    break;
-                case STRUCT:
-                    handleStructField(doc, (Struct) struct.get(field), field);
-                    break;
-                case ARRAY:
-                    doc.put(field.name(), handleArrayField((List) struct.get(field), field));
-                    break;
-                case MAP:
-                    handleMapField(doc, (Map) struct.get(field), field);
-                    break;
-                default:
-                    throw new DataException("unexpected / unsupported schema type " + field.schema().type());
+            value = handleLogicalTypeField(struct.get(field), field);
+        } else {
+            try {
+                switch (field.schema().type()) {
+                    case BOOLEAN:
+                    case FLOAT32:
+                    case FLOAT64:
+                    case INT8:
+                    case INT16:
+                    case INT32:
+                    case INT64:
+                    case STRING:
+                    case BYTES:
+                        value = handlePrimitiveField(struct.get(field), field);
+                        break;
+                    case STRUCT:
+                        value = handleStructField((Struct) struct.get(field), field);
+                        break;
+                    case ARRAY:
+                        value = handleArrayField((List) struct.get(field), field);
+                        break;
+                    case MAP:
+                        value = handleMapField((Map) struct.get(field), field);
+                        break;
+                    default:
+                        throw new DataException("unexpected / unsupported schema type " + field.schema().type());
+                }
+            } catch (Exception exc) {
+                logger.error("Error processing field '{}' of type '{}': {}",
+                             field.name(), field.schema().type(), exc.getMessage());
+                throw new DataException("error while processing field " + field.name(), exc);
             }
-        } catch (Exception exc) {
-            logger.error("Error processing field '{}' of type '{}': {}",
-                         field.name(), field.schema().type(), exc.getMessage());
-            throw new DataException("error while processing field " + field.name(), exc);
         }
+
+        doc.put(field.name(), value);
     }
 
-    private void handleLogicalTypeField(BsonDocument doc, Object value, Field field) {
+    private BsonValue handleLogicalTypeField(Object value, Field field) {
         logger.trace("handling logical type '{}' name='{}'", field.schema().name(), field.name());
-        doc.put(field.name(), getConverter(field.schema()).toBson(value, field.schema()));
+        return getConverter(field.schema()).toBson(value, field.schema());
     }
 
-    private void handleMapField(BsonDocument doc, Map m, Field field) {
+    private BsonValue handleMapField(Map m, Field field) {
         logger.trace("handling map field='{}' valueSchema.type='{}'",
                      field.name(), field.schema().valueSchema().type());
 
         if (m == null) {
             logger.trace("  field='{}' has null map", field.name());
-            doc.put(field.name(), BsonNull.VALUE);
-            return;
+            return BsonNull.VALUE;
         }
 
-        BsonDocument mapDoc = convertMapValue(field.schema(), (Map<String, Object>) m);
-        doc.put(field.name(), mapDoc);
+        return convertMapValue(field.schema(), (Map<String, Object>) m);
     }
 
     private BsonValue handleArrayField(List list, Field field) {
@@ -194,14 +195,13 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         return array;
     }
 
-    private void handleStructField(BsonDocument doc, Struct struct, Field field) {
+    private BsonValue handleStructField(Struct struct, Field field) {
         logger.trace("handling struct field='{}' schema.name='{}' schema.type='{}'",
                      field.name(), field.schema().name(), field.schema().type());
 
         if (struct == null) {
             logger.trace("  field='{}' has null struct value", field.name());
-            doc.put(field.name(), BsonNull.VALUE);
-            return;
+            return BsonNull.VALUE;
         }
 
         logger.trace("  struct value: {}", struct.toString());
@@ -211,10 +211,12 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
                      isUnion, unionUnwrapEnabled, field.schema().name());
 
         if (isUnion) {
-            unwrapAndPutUnion(doc, struct, field);
+            BsonDocument tempDoc = new BsonDocument();
+            unwrapAndPutUnion(tempDoc, struct, field);
+            return tempDoc.get(field.name());
         } else {
             logger.trace("  processing as regular struct with {} fields", field.schema().fields().size());
-            doc.put(field.name(), toBsonDoc(field.schema(), struct));
+            return toBsonDoc(field.schema(), struct);
         }
     }
 
@@ -321,9 +323,9 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         return mapDoc;
     }
 
-    private void handlePrimitiveField(BsonDocument doc, Object value, Field field) {
+    private BsonValue handlePrimitiveField(Object value, Field field) {
         logger.trace("handling primitive type '{}' name='{}'", field.schema().type(), field.name());
-        doc.put(field.name(), getConverter(field.schema()).toBson(value, field.schema()));
+        return getConverter(field.schema()).toBson(value, field.schema());
     }
 
     private boolean isSupportedLogicalType(Schema schema) {

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -61,6 +61,18 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         registerLogicalConverters();
     }
 
+    @Override
+    public BsonDocument convert(Schema schema, Object value) {
+        if (schema == null || value == null) {
+            throw new DataException("error: schema and/or value was null for AVRO conversion");
+        }
+
+        logger.trace("convert() entry: schema.name='{}' schema.type='{}' value.class='{}'",
+                     schema.name(), schema.type(), value.getClass().getSimpleName());
+
+        return toBsonDoc(schema, value);
+    }
+
     private void registerStandardConverters() {
         registerSinkFieldConverter(new BooleanFieldConverter());
         registerSinkFieldConverter(new Int8FieldConverter());
@@ -80,18 +92,6 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         registerSinkFieldLogicalConverter(new DecimalFieldConverter());
     }
 
-    @Override
-    public BsonDocument convert(Schema schema, Object value) {
-        if (schema == null || value == null) {
-            throw new DataException("error: schema and/or value was null for AVRO conversion");
-        }
-
-        logger.trace("convert() entry: schema.name='{}' schema.type='{}' value.class='{}'",
-                     schema.name(), schema.type(), value.getClass().getSimpleName());
-
-        return toBsonDoc(schema, value);
-    }
-
     private void registerSinkFieldConverter(SinkFieldConverter converter) {
         converters.put(converter.getSchema().type(), converter);
     }
@@ -104,15 +104,6 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         BsonDocument doc = new BsonDocument();
         schema.fields().forEach(f -> processField(doc, (Struct) value, f));
         return doc;
-    }
-
-    /**
-     * Detects if a schema represents an Avro union type using Confluent's marker.
-     */
-    private boolean isUnionStruct(Schema schema) {
-        return schema != null
-               && schema.type() == Schema.Type.STRUCT
-               && CONFLUENT_UNION_MARKER.equals(schema.name());
     }
 
     private void processField(BsonDocument doc, Struct struct, Field field) {
@@ -128,42 +119,8 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         }
     }
 
-    private BsonValue convertSimpleValue(Schema schema, Object value) {
-        if (isSupportedLogicalType(schema)) {
-            logger.trace("converting logical type '{}'", schema.name());
-        } else {
-            logger.trace("converting primitive type '{}'", schema.type());
-        }
-
-        return getConverter(schema).toBson(value, schema);
-    }
-
-    /**
-     * Unwraps an Avro union struct and returns the selected branch value.
-     * Union structs have multiple optional fields (one per branch), but only one should be non-null.
-     */
-    private BsonValue unwrapUnion(Schema schema, Struct struct) {
-        logger.trace("unwrapping union schema.name='{}'", schema.name());
-
-        for (Field unionBranch : schema.fields()) {
-            Object branchValue = struct.get(unionBranch);
-            logger.trace("  union branch='{}' type='{}' value.isNull={}",
-                         unionBranch.name(), unionBranch.schema().type(), branchValue == null);
-
-            if (branchValue != null) {
-                logger.trace("  selected branch='{}' type='{}' - unwrapping to parent field",
-                             unionBranch.name(), unionBranch.schema().type());
-                return convertValue(unionBranch.schema(), branchValue);
-            }
-        }
-
-        logger.trace("  all union branches null - returning BsonNull");
-        return BsonNull.VALUE;
-    }
-
     /**
      * Converts a value based on its schema type. Handles primitives, structs, arrays, and maps.
-     * This is a central conversion point that eliminates duplication.
      */
     private BsonValue convertValue(Schema schema, Object value) {
         if (value == null) {
@@ -186,6 +143,16 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
             default:
                 throw new DataException("Unsupported schema type: " + type);
         }
+    }
+
+    private BsonValue convertSimpleValue(Schema schema, Object value) {
+        if (isSupportedLogicalType(schema)) {
+            logger.trace("converting logical type '{}'", schema.name());
+        } else {
+            logger.trace("converting primitive type '{}'", schema.type());
+        }
+
+        return getConverter(schema).toBson(value, schema);
     }
 
     /**
@@ -245,6 +212,29 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         return mapDoc;
     }
 
+    /**
+     * Unwraps an Avro union struct and returns the selected branch value.
+     * Union structs have multiple optional fields (one per branch), but only one should be non-null.
+     */
+    private BsonValue unwrapUnion(Schema schema, Struct struct) {
+        logger.trace("unwrapping union schema.name='{}'", schema.name());
+
+        for (Field unionBranch : schema.fields()) {
+            Object branchValue = struct.get(unionBranch);
+            logger.trace("  union branch='{}' type='{}' value.isNull={}",
+                         unionBranch.name(), unionBranch.schema().type(), branchValue == null);
+
+            if (branchValue != null) {
+                logger.trace("  selected branch='{}' type='{}' - unwrapping to parent field",
+                             unionBranch.name(), unionBranch.schema().type());
+                return convertValue(unionBranch.schema(), branchValue);
+            }
+        }
+
+        logger.trace("  all union branches null - returning BsonNull");
+        return BsonNull.VALUE;
+    }
+
     private boolean isSupportedLogicalType(Schema schema) {
         return schema.name() != null && LOGICAL_TYPE_NAMES.contains(schema.name());
     }
@@ -263,5 +253,14 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         }
 
         return converter;
+    }
+
+    /**
+     * Detects if a schema represents an Avro union type using Confluent's marker.
+     */
+    private boolean isUnionStruct(Schema schema) {
+        return schema != null
+               && schema.type() == Schema.Type.STRUCT
+               && CONFLUENT_UNION_MARKER.equals(schema.name());
     }
 }

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -57,8 +57,11 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
 
     public AvroJsonSchemafulRecordConverter(boolean unionUnwrapEnabled) {
         this.unionUnwrapEnabled = unionUnwrapEnabled;
+        registerStandardConverters();
+        registerLogicalConverters();
+    }
 
-        //standard types
+    private void registerStandardConverters() {
         registerSinkFieldConverter(new BooleanFieldConverter());
         registerSinkFieldConverter(new Int8FieldConverter());
         registerSinkFieldConverter(new Int16FieldConverter());
@@ -68,8 +71,9 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         registerSinkFieldConverter(new Float64FieldConverter());
         registerSinkFieldConverter(new StringFieldConverter());
         registerSinkFieldConverter(new BytesFieldConverter());
+    }
 
-        //logical types
+    private void registerLogicalConverters() {
         registerSinkFieldLogicalConverter(new DateFieldConverter());
         registerSinkFieldLogicalConverter(new TimeFieldConverter());
         registerSinkFieldLogicalConverter(new TimestampFieldConverter());

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -224,8 +224,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
             case STRUCT:
                 return convertStructValue(schema, (Struct) value);
             case ARRAY:
-                Field arrayField = new Field("temp", 0, schema);
-                return handleArrayField((List) value, arrayField);
+                return convertArrayValue(schema, (List) value);
             case MAP:
                 return convertMapValue(schema, (Map<String, Object>) value);
             default:

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -119,7 +119,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         logger.trace("processing field '{}'", field.name());
 
         if (isSupportedLogicalType(field.schema())) {
-            doc.put(field.name(), getConverter(field.schema()).toBson(struct.get(field), field.schema()));
+            handleLogicalTypeField(doc, struct.get(field), field);
             return;
         }
 
@@ -153,6 +153,11 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
                          field.name(), field.schema().type(), exc.getMessage());
             throw new DataException("error while processing field " + field.name(), exc);
         }
+    }
+
+    private void handleLogicalTypeField(BsonDocument doc, Object value, Field field) {
+        logger.trace("handling logical type '{}' name='{}'", field.schema().name(), field.name());
+        doc.put(field.name(), getConverter(field.schema()).toBson(value, field.schema()));
     }
 
     private void handleMapField(BsonDocument doc, Map m, Field field) {

--- a/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
+++ b/src/main/java/com/github/cedelsb/kafka/connect/smt/converter/AvroJsonSchemafulRecordConverter.java
@@ -208,7 +208,7 @@ public class AvroJsonSchemafulRecordConverter implements RecordConverter {
         Schema.Type type = schema.type();
 
         if (type.isPrimitive() || isSupportedLogicalType(schema)) {
-            return getConverter(schema).toBson(value, schema);
+            return convertSimpleValue(schema, value);
         }
 
         switch (type) {

--- a/src/test/java/com/github/cedelsb/kafka/connect/smt/converter/RecordConverterTest.java
+++ b/src/test/java/com/github/cedelsb/kafka/connect/smt/converter/RecordConverterTest.java
@@ -287,6 +287,43 @@ public class RecordConverterTest {
                 () -> assertThrows(DataException.class, () -> converter.convert(null,null))
         );
     }
+
+    @Test
+    @DisplayName("test map with null struct values")
+    public void testMapWithNullStructValues() {
+        RecordConverter converter = new AvroJsonSchemafulRecordConverter();
+
+        Schema itemSchema = SchemaBuilder.struct()
+                .field("id", Schema.INT32_SCHEMA)
+                .field("name", Schema.STRING_SCHEMA)
+                .optional()
+                .build();
+
+        Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, itemSchema).optional().build();
+        Schema schema = SchemaBuilder.struct().field("items", mapSchema).build();
+
+        Map<String, Struct> mapValue = new HashMap<>();
+        mapValue.put("item1", new Struct(itemSchema).put("id", 1).put("name", "Alice"));
+        mapValue.put("item2", new Struct(itemSchema).put("id", 2).put("name", "Bob"));
+        mapValue.put("item3", null);  // null value in map
+
+        Struct struct = new Struct(schema).put("items", mapValue);
+
+        BsonDocument result = converter.convert(schema, struct);
+        BsonDocument mapDoc = result.getDocument("items");
+
+        assertEquals(3, mapDoc.size());
+
+        BsonDocument item1 = mapDoc.getDocument("item1");
+        assertEquals(1, item1.getInt32("id").getValue());
+        assertEquals("Alice", item1.getString("name").getValue());
+
+        BsonDocument item2 = mapDoc.getDocument("item2");
+        assertEquals(2, item2.getInt32("id").getValue());
+        assertEquals("Bob", item2.getString("name").getValue());
+
+        assertTrue(mapDoc.get("item3").isNull());
+    }
 /*
     @Test
     @DisplayName("test json object conversion")

--- a/src/test/java/com/github/cedelsb/kafka/connect/smt/converter/RecordConverterTest.java
+++ b/src/test/java/com/github/cedelsb/kafka/connect/smt/converter/RecordConverterTest.java
@@ -324,6 +324,181 @@ public class RecordConverterTest {
 
         assertTrue(mapDoc.get("item3").isNull());
     }
+
+    @Test
+    @DisplayName("test union unwrapping disabled by default")
+    public void testUnionUnwrappingDisabledByDefault() {
+        RecordConverter converter = new AvroJsonSchemafulRecordConverter();
+
+        // Create union schema: union[null, string]
+        Schema unionSchema = SchemaBuilder.struct()
+                .name("io.confluent.connect.avro.Union")
+                .field("null", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("string", Schema.OPTIONAL_STRING_SCHEMA)
+                .optional()
+                .build();
+
+        Schema rootSchema = SchemaBuilder.struct()
+                .field("myUnion", unionSchema)
+                .build();
+
+        Struct unionValue = new Struct(unionSchema).put("string", "test");
+        Struct rootStruct = new Struct(rootSchema).put("myUnion", unionValue);
+
+        BsonDocument result = converter.convert(rootSchema, rootStruct);
+
+        // With unwrapping disabled, union should be output as a document with all branches
+        BsonDocument unionDoc = result.getDocument("myUnion");
+        assertTrue(unionDoc.get("null").isNull());
+        assertEquals("test", unionDoc.getString("string").getValue());
+    }
+
+    @Test
+    @DisplayName("test union unwraps to actual value")
+    public void testUnionUnwrapsToActualValue() {
+        RecordConverter converter = new AvroJsonSchemafulRecordConverter(true);
+
+        // Create union schema: union[null, string]
+        Schema unionSchema = SchemaBuilder.struct()
+                .name("io.confluent.connect.avro.Union")
+                .field("null", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("string", Schema.OPTIONAL_STRING_SCHEMA)
+                .optional()
+                .build();
+
+        Schema rootSchema = SchemaBuilder.struct()
+                .field("myUnion", unionSchema)
+                .build();
+
+        Struct unionValue = new Struct(unionSchema).put("string", "test");
+        Struct rootStruct = new Struct(rootSchema).put("myUnion", unionValue);
+
+        BsonDocument result = converter.convert(rootSchema, rootStruct);
+
+        // Union should be unwrapped - value should be directly a string, not wrapped
+        assertEquals("test", result.getString("myUnion").getValue());
+    }
+
+    @Test
+    @DisplayName("test union with all null branches returns BsonNull")
+    public void testUnionWithAllNullBranches() {
+        RecordConverter converter = new AvroJsonSchemafulRecordConverter(true);
+
+        // Create union schema: union[null, string]
+        Schema unionSchema = SchemaBuilder.struct()
+                .name("io.confluent.connect.avro.Union")
+                .field("null", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("string", Schema.OPTIONAL_STRING_SCHEMA)
+                .optional()
+                .build();
+
+        Schema rootSchema = SchemaBuilder.struct()
+                .field("myUnion", unionSchema)
+                .build();
+
+        Struct unionValue = new Struct(unionSchema); // All fields null
+        Struct rootStruct = new Struct(rootSchema).put("myUnion", unionValue);
+
+        BsonDocument result = converter.convert(rootSchema, rootStruct);
+
+        // Union with all null branches should output BsonNull
+        assertTrue(result.get("myUnion").isNull());
+    }
+
+    @Test
+    @DisplayName("test map with union-typed values unwraps correctly")
+    public void testMapWithUnionValues() {
+        RecordConverter converter = new AvroJsonSchemafulRecordConverter(true);
+
+        // Create union schema for map values: union[null, string, int, boolean]
+        Schema unionSchema = SchemaBuilder.struct()
+                .name("io.confluent.connect.avro.Union")
+                .field("null", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("string", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("int", Schema.OPTIONAL_INT32_SCHEMA)
+                .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+                .optional()
+                .build();
+
+        Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, unionSchema).build();
+
+        Schema rootSchema = SchemaBuilder.struct()
+                .field("data", mapSchema)
+                .build();
+
+        // Create map with different union value types
+        Map<String, Struct> mapData = new HashMap<>();
+        mapData.put("field1", new Struct(unionSchema).put("string", "value1"));
+        mapData.put("field2", new Struct(unionSchema).put("int", 100));
+        mapData.put("field3", new Struct(unionSchema).put("boolean", true));
+        mapData.put("field4", new Struct(unionSchema)); // All null
+
+        Struct rootStruct = new Struct(rootSchema).put("data", mapData);
+
+        BsonDocument result = converter.convert(rootSchema, rootStruct);
+        BsonDocument dataDoc = result.getDocument("data");
+
+        assertEquals(4, dataDoc.size());
+
+        // All union values should be unwrapped to their actual values
+        assertEquals("value1", dataDoc.getString("field1").getValue());
+        assertEquals(100, dataDoc.getInt32("field2").getValue());
+        assertTrue(dataDoc.getBoolean("field3").getValue());
+        assertTrue(dataDoc.get("field4").isNull());
+    }
+
+    @Test
+    @DisplayName("test nested unions - union containing map with union values")
+    public void testNestedUnions() {
+        RecordConverter converter = new AvroJsonSchemafulRecordConverter(true);
+
+        // Inner union: union[null, string, int] for map values
+        Schema innerUnionSchema = SchemaBuilder.struct()
+                .name("io.confluent.connect.avro.Union")
+                .field("null", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("string", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("int", Schema.OPTIONAL_INT32_SCHEMA)
+                .optional()
+                .build();
+
+        Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, innerUnionSchema).optional().build();
+
+        // Outer union: union[null, map]
+        Schema outerUnionSchema = SchemaBuilder.struct()
+                .name("io.confluent.connect.avro.Union")
+                .field("null", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("map", mapSchema)
+                .optional()
+                .build();
+
+        Schema rootSchema = SchemaBuilder.struct()
+                .field("id", Schema.STRING_SCHEMA)
+                .field("data", outerUnionSchema)
+                .build();
+
+        // Create nested structure: outer union contains map with inner union values
+        Map<String, Struct> mapData = new HashMap<>();
+        mapData.put("currency", new Struct(innerUnionSchema).put("string", "USD"));
+        mapData.put("amount", new Struct(innerUnionSchema).put("int", 100));
+
+        Struct outerUnion = new Struct(outerUnionSchema).put("map", mapData);
+        Struct rootStruct = new Struct(rootSchema)
+                .put("id", "test-123")
+                .put("data", outerUnion);
+
+        BsonDocument result = converter.convert(rootSchema, rootStruct);
+
+        assertEquals("test-123", result.getString("id").getValue());
+
+        // Outer union should be unwrapped to just the map
+        BsonDocument dataDoc = result.getDocument("data");
+        assertEquals(2, dataDoc.size());
+
+        // Inner union values should also be unwrapped
+        assertEquals("USD", dataDoc.getString("currency").getValue());
+        assertEquals(100, dataDoc.getInt32("amount").getValue());
+    }
+
 /*
     @Test
     @DisplayName("test json object conversion")


### PR DESCRIPTION
Thanks for this project! I have found it very useful, although I had to make some adjustments to support the kind of Avro schema I needed to handle, namely:

* Handle null Struct values inside maps, which were leading to `NullPointerException`
* Support *unwrapping* the representation of Avro unions back into their original flat representation (e.g.: turn `{"field": {"null": null, "string": "test", "int": null}}` into `{"field": "test"}`). This is an opt-in feature that must be explicitly enabled with `transforms.tojson.avro.union.unwrap.enabled: true`, for backwards compatibility.
* Extend tracing logs, which I found useful during development.
* Refactoring. Some of it needed to implement the Avro union unwrapping. Some of it just to try to reduce duplication, make the implementation cleaner, etc.

This is code that I'm currently running in production and would love to integrate upstream, if you find it valuable.

I'm well aware this is a big PR, although, hopefully, commits are granular and documented enough to make the review easier. Let me know if you prefer that I create smaller (but still meaningful) PRs, one at a time.